### PR TITLE
BaseMetadata subclasses which share a ckan_data_type are now banned

### DIFF
--- a/bpaingest/projects/__init__.py
+++ b/bpaingest/projects/__init__.py
@@ -3,12 +3,8 @@ from .amdb.ingest import (
     BASEMetagenomicsMetadata,
     BASEAmpliconsControlMetadata,
     BASESiteImagesMetadata,
-    MarineMicrobesGenomicsAmplicons16SMetadata,
-    MarineMicrobesGenomicsAmpliconsA16SMetadata,
-    MarineMicrobesGenomicsAmplicons18SMetadata,
-    MarineMicrobesGenomicsAmplicons16SControlMetadata,
-    MarineMicrobesGenomicsAmpliconsA16SControlMetadata,
-    MarineMicrobesGenomicsAmplicons18SControlMetadata,
+    MarineMicrobesAmpliconsMetadata,
+    MarineMicrobesAmpliconsControlMetadata,
     MarineMicrobesMetagenomicsMetadata,
     MarineMicrobesMetatranscriptomeMetadata)
 from .gbr.ingest import (
@@ -64,12 +60,8 @@ class ProjectInfo:
             GbrPacbioMetadata,
         ],
         'marine-microbes': [
-            MarineMicrobesGenomicsAmplicons16SMetadata,
-            MarineMicrobesGenomicsAmpliconsA16SMetadata,
-            MarineMicrobesGenomicsAmplicons18SMetadata,
-            MarineMicrobesGenomicsAmplicons16SControlMetadata,
-            MarineMicrobesGenomicsAmpliconsA16SControlMetadata,
-            MarineMicrobesGenomicsAmplicons18SControlMetadata,
+            MarineMicrobesAmpliconsMetadata,
+            MarineMicrobesAmpliconsControlMetadata,
             MarineMicrobesMetagenomicsMetadata,
             MarineMicrobesMetatranscriptomeMetadata,
         ],
@@ -115,7 +107,7 @@ class ProjectInfo:
         'wheat-pathogens': [
             WheatPathogensGenomesMetadata,  # the first half of wheat pathogens
         ],
-    }
+   }
 
     def __init__(self):
         self.metadata_info = self._build_metadata_info()

--- a/bpaingest/schema.py
+++ b/bpaingest/schema.py
@@ -171,8 +171,12 @@ def generate_schemas(args):
         with DownloadMetadata(project_cls, path=dlpath) as dlmeta:
             meta = dlmeta.meta
             data_type = meta.ckan_data_type
-            package_field_mapping[data_type].update(getattr(meta, 'package_field_names', {}))
-            resource_field_mapping[data_type].update(getattr(meta, 'resource_field_names', {}))
+            # multiple Metadata classes producing the same data type makes delete unsafe
+            # as it becomes difficult to assert that all packages of the type have been
+            # defined by a single bpa-ingest run
+            assert(data_type not in package_keys)
+            package_field_mapping[data_type] = getattr(meta, 'package_field_names', {})
+            resource_field_mapping[data_type] = getattr(meta, 'resource_field_names', {})
             for package in meta.get_packages():
                 package_keys[data_type].update(list(package.keys()))
             for _, _, resource in meta.get_resources():


### PR DESCRIPTION
 - convert MM Amplicon to work within this new paradigm
 - convert MM Amplicon Control to work within this new paradigm
 - `--delete` should now be safe, although still to be used with caution
 - fix NCBI ingest, which had broken